### PR TITLE
Adding support for custom properties

### DIFF
--- a/packages/client/src/types/index.ts
+++ b/packages/client/src/types/index.ts
@@ -79,6 +79,7 @@ export type TalentLayerProfile = {
     name?: string;
     about?: string;
     skills?: string;
+    [key: string]: any
 }
 
 export type ProposalDetails = {
@@ -104,6 +105,7 @@ export type ServiceDetails = {
     keywords: string,
     rateToken: string,
     rateAmount: string,
+    [key: string]: any
 }
 
 export type ReviewDetails = {


### PR DESCRIPTION
Now, when creating a proposal or updating user profile, consumer can upload any custom properties they want to ipfs

This PR also removes the need to pass `value` to escrow.approve function. The value is now calculated implicitly