### PR TITLE
We shall multisig !!!

### DIFF
--- a/packages/client/src/types/index.ts
+++ b/packages/client/src/types/index.ts
@@ -1,4 +1,4 @@
-import { Chain, Hash } from 'viem';
+import { Chain, Hash, WalletClient } from 'viem';
 
 export type IToken = {
   name: string;
@@ -45,6 +45,7 @@ export type ViemClientConfig = {
   privateKey?: `0x${string}`;
   mnemonic?: string;
   chainId?: NetworkEnum;
+  walletClient?: WalletClient;
 };
 
 type Currency = {

--- a/packages/client/src/viem/index.ts
+++ b/packages/client/src/viem/index.ts
@@ -69,6 +69,17 @@ export class ViemClient {
       return true;
     }
 
+    /*
+    * If consumer passes a walletClient, we use that directly.
+    * This enabled the compatibility of the sdk with multisig wallets like safe
+    */
+    if (config?.walletClient) {
+      console.log('SDK: viem client - wallet client object found', config?.walletClient);
+      this.client = config.walletClient;
+      console.log('SDK: viem client - initalised successfully with custom wallet client!');
+      return true;
+    }
+
     // @ts-ignore
     let browserProvider = globalThis?.ethereum || window?.ethereum;
     if (browserProvider) {
@@ -91,6 +102,9 @@ export class ViemClient {
   ): Promise<Hash> {
     // @ts-ignore
     const [address] = await this.client.getAddresses();
+
+    const accounts = await this.client.requestAddresses();
+    console.log('SDK: viem accounts request', accounts);
 
     if (!address) {
       throw Error('Wallet Client not initialised properly');

--- a/packages/client/src/viem/index.ts
+++ b/packages/client/src/viem/index.ts
@@ -103,9 +103,6 @@ export class ViemClient {
     // @ts-ignore
     const [address] = await this.client.getAddresses();
 
-    const accounts = await this.client.requestAddresses();
-    console.log('SDK: viem accounts request', accounts);
-
     if (!address) {
       throw Error('Wallet Client not initialised properly');
     }


### PR DESCRIPTION
This PR adds support for custom walletClients. This approach is especially useful when using wagmi / walletconnect/ web3modal ( or all of the above)
Consumers can now pass the walletClient they want to use instead of relying on the one generated by the SDK

for instance, in the builder-place, we can now do:

```
const { data: walletClient } = useWalletClient();
const talentLayerClient = new TalentLayerClient({
      chainId: process.env.NEXT_PUBLIC_DEFAULT_CHAIN_ID as unknown as number,
      ipfsConfig: {
        clientId: process.env.NEXT_PUBLIC_INFURA_ID as string,
        clientSecret: process.env.NEXT_PUBLIC_INFURA_SECRET as string,
        baseUrl: process.env.NEXT_PUBLIC_IPFS_WRITE_URL as string,
      },
      platformId: parseInt(process.env.NEXT_PUBLIC_PLATFORM_ID as string),
      signatureApiUrl: process.env.NEXT_PUBLIC_SIGNATURE_API_URL as string,
+      walletConfig: {
+        walletClient
+     }
    });
```

This approach will remove reliance on browser provider as the fallback. 
